### PR TITLE
Enable local logging if imuxsock module is enabled.

### DIFF
--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -37,10 +37,10 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 
 # Turn off message reception via local log socket;
 # local messages are retrieved through imjournal now.
-$OmitLocalLogging on
+{{ '#' if 'imuxsock' in rsyslog_mods else '' }}$OmitLocalLogging on
 
 # File to store the position in the journal
-$IMJournalStateFile imjournal.state
+{{ '#' if not 'imjournal' in rsyslog_mods else '' }}$IMJournalStateFile imjournal.state
 
 # Set mode for new files and directories
 $DirCreateMode {{ rsyslog_dircreatemode }}


### PR DESCRIPTION
---
name: Pull request
about: This expands on #4 a bit to better support older OSs without journald. (RHEL / CentOS 6)

---

**Describe the change**

* Don't omit local logging if imuxsock module is enabled.  
* Clean up logged (non-fatal) errors if imjournal is not being used.

**Testing**
Tested by invoking role with various `rsyslog_mods` lists in CenOS 6/7 and checking log for errors.  Checked with and without imuxsock and imjournal.
