### PR TITLE
Add configurations for remote selector/port/protocol. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ These variables are set in `defaults/main.yml`:
 # Not setting this variable will not forward logs.
 # rsyslog_remote: server1.example.com
 
+# If rsylog_remote is set, sets the "selector" pattern for determining which
+# messages to send to the remote server.  Default "*.*" sends everything.
+# See `man rsyslog.conf`.
+rsyslog_remote_selector: "*.*"
+
+# If rsylog_remote is set, use TCP if true.  UDP if false.
+rsyslog_remote_tcp: true
+
+# If rsylog_remote is set, destination port to use.
+rsyslog_remote_port: "514"
+
 # Set the mode for new directories
 rsyslog_dircreatemode: "0700"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,17 @@
 # Not setting this variable will not forward logs.
 # rsyslog_remote: server1.example.com
 
+# If rsylog_remote is set, sets the "selector" pattern for determining which
+# messages to send to the remote server.  Default "*.*" sends everything.
+# See `man rsyslog.conf`.
+rsyslog_remote_selector: "*.*"
+
+# If rsylog_remote is set, use TCP if true.  UDP if false.
+rsyslog_remote_tcp: true
+
+# If rsylog_remote is set, destination port to use.
+rsyslog_remote_port: "514"
+
 # Set the mode for new directories
 rsyslog_dircreatemode: "0700"
 

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -93,7 +93,7 @@ local7.*                                                /var/log/boot.log
 # remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
 #*.* @@remote-host:514
 {% if rsyslog_remote is defined %}
-*.* @@{{ rsyslog_remote }}:514
+{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
 {% endif %}
 # ### end of the forwarding rule ###
 {% endif %}


### PR DESCRIPTION
name: Pull request
about: Add configurations for remote selector/port/protocol. 

---

**Describe the change**
This adds some simple vars to configure the remote's message selector, protocol, and port.  Defaults the same as existing template to avoid interface change.

**Testing**
Tested in CentOS 6 / CentOS 7.
