### PR TITLE
add rsyslog_enable var

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ These variables are set in `defaults/main.yml`:
 ---
 # defaults file for rsyslog
 
+# Set rsyslog_enable to false to completely disable the role
+rsyslog_enable: yes
+
 # To configure a server to reveice logs, set rsyslog_receiver to yes.
 # Not setting this value will not configure the server tor receive logs.
 # rsyslog_receiver: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for rsyslog
 
+# Set rsyslog_enable to false to completely disable the role
+rsyslog_enable: yes
+
 # To configure a server to reveice logs, set rsyslog_receiver to yes.
 # Not setting this value will not configure the server tor receive logs.
 # rsyslog_receiver: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,32 +4,37 @@
   include_tasks: assert.yml
   run_once: yes
 
-- name: uninstall conflicting systemd-logger
-  package:
-    name: systemd-logger
-    state: absent
+- name: manage ryslog
+  block:
 
-- name: install rsyslog
-  package:
-    name: "{{ rsyslog_packages }}"
-    state: present
+    - name: uninstall conflicting systemd-logger
+      package:
+        name: systemd-logger
+        state: absent
 
-- name: configuring rsyslog
-  template:
-    src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
-    dest: /etc/rsyslog.conf
-    mode: "0644"
-  notify:
-    - restart rsyslog
+    - name: install rsyslog
+      package:
+        name: "{{ rsyslog_packages }}"
+        state: present
 
-- name: make configuration directory
-  file:
-    name: /etc/rsyslog.d/
-    state: directory
-    mode: "0755"
+    - name: configuring rsyslog
+      template:
+        src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
+        dest: /etc/rsyslog.conf
+        mode: "0644"
+      notify:
+        - restart rsyslog
 
-- name: start and enable rsyslog
-  service:
-    name: "{{ rsyslog_service }}"
-    state: started
-    enabled: yes
+    - name: make configuration directory
+      file:
+        name: /etc/rsyslog.d/
+        state: directory
+        mode: "0755"
+
+    - name: start and enable rsyslog
+      service:
+        name: "{{ rsyslog_service }}"
+        state: started
+        enabled: yes
+
+  when: rsyslog_enable | bool


### PR DESCRIPTION
---
name: add rsyslog_enable var
about: Add a variable to completely disable the role

---

**Describe the change**
Hi Robert, as usual, thanks so much for your fantastic roles.
I've added a variable to completely disable the role.

This role works for about 90% of my systems, however I'm not able to use it for some.
I'm using this in Red Hat Satellite (Foreman), in which roles are assigned to groups of hosts, but can't be removed from sub-groups.
The intention is to have a method to easily disable this role with a variable, rather than creating a duplicate group without the role.

Not sure how this fits with your plans for this role, however I've seen similar mechanisms in other roles I use, e.g. `ssh_enable` in [willshersystems.sshd](https://github.com/willshersystems/ansible-sshd).

**Testing**
I've run the standard Molecule tests.
