### PR TITLE
Added forward rule in rsyslog directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,6 @@ rsyslog_deploy_default_config: yes
 # More information on the different formats on the rsyslog website:
 # https://www.rsyslog.com/doc/v8-stable/configuration/conf_formats.html
 rsyslog_config_file_format: legacy
+
+# The rule conf to name to add to /etc/rsyslog.d/
+# rsyslog_forward_rule_name: <to fill>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,10 +22,10 @@ rsyslog_remote_tcp: yes
 rsyslog_remote_port: 514
 
 # Set the mode for new directories; only available in legacy template.
-rsyslog_dircreatemode: "0700"
+rsyslog_dircreatemode: 0700
 
 # Set the mode for new files; only available in legacy template.
-rsyslog_filecreatemode: "0644"
+rsyslog_filecreatemode: 0644
 
 # Set the mods enabled
 rsyslog_mods:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -36,16 +36,14 @@
   assert:
     that:
       - rsyslog_dircreatemode is defined
-      - rsyslog_dircreatemode | int
-      - rsyslog_dircreatemode | regex_search('^0')
+      - rsyslog_dircreatemode is number
     quiet: yes
 
 - name: test if rsyslog_filecreatemode is set correctly
   assert:
     that:
       - rsyslog_filecreatemode is defined
-      - rsyslog_filecreatemode | int
-      - rsyslog_filecreatemode | regex_search('^0')
+      - rsyslog_filecreatemode is number
     quiet: yes
 
 - name: test if rsyslog_mods is set correctly
@@ -77,11 +75,11 @@
       - rsyslog_forward_rule_name is defined
     quiet: yes
   when:
-    - rsyslog_deploy_default_config == False
+    - rsyslog_deploy_default_config == "no"
 
 - name: test if rsyslog_config_file_format is set correctly
   assert:
     that:
       - rsyslog_config_file_format is defined
-      - rsyslog_config_file_format in ['legacy', 'advanced']
+      - rsyslog_config_file_format in ["legacy", "advanced"]
     quiet: yes

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -71,9 +71,17 @@
       - rsyslog_deploy_default_config | type_debug == "bool"
     quiet: yes
 
+- name: test if rsyslog_forward_rule_name is set correctly
+  assert:
+    that:
+      - rsyslog_forward_rule_name is defined
+    quiet: yes
+  when:
+    - rsyslog_deploy_default_config == False
+
 - name: test if rsyslog_config_file_format is set correctly
   assert:
     that:
       - rsyslog_config_file_format is defined
-      - rsyslog_config_file_format in ["legacy", "advanced"]
+      - rsyslog_config_file_format in ['legacy', 'advanced']
     quiet: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
     dest: /etc/rsyslog.conf
     mode: "0644"
-  when: rsyslog_deploy_default_config == True
+  when: rsyslog_deploy_default_config == "yes"
   notify:
     - restart rsyslog
 
@@ -34,7 +34,7 @@
     src: "forward_rule.conf.j2"
     dest: /etc/rsyslog.d/{{ rsyslog_forward_rule_name }}.conf
     mode: "0644"
-  when: rsyslog_deploy_default_config == False
+  when: rsyslog_deploy_default_config == "no"
   notify:
     - restart rsyslog
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,12 @@
     name: "{{ rsyslog_packages }}"
     state: present
 
-- name: configuring rsyslog
+- name: configuring default rsyslog
   template:
     src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
     dest: /etc/rsyslog.conf
     mode: "0644"
+  when: rsyslog_deploy_default_config == True
   notify:
     - restart rsyslog
 
@@ -27,6 +28,15 @@
     name: /etc/rsyslog.d/
     state: directory
     mode: "0755"
+
+- name: configuring {{ rsyslog_forward_rule_name }} rsyslog forward rule
+  template:
+    src: "forward_rule.conf.j2"
+    dest: /etc/rsyslog.d/{{ rsyslog_forward_rule_name }}.conf
+    mode: "0644"
+  when: rsyslog_deploy_default_config == False
+  notify:
+    - restart rsyslog
 
 - name: start and enable rsyslog
   service:

--- a/templates/forward_rule.conf.j2
+++ b/templates/forward_rule.conf.j2
@@ -1,0 +1,36 @@
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+
+{% if rsyslog_remote is defined  and rsyslog_config_file_format == 'legacy' %}
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
+{% endif %}
+# ### end of the forwarding rule ###
+
+{% if rsyslog_remote is defined and rsyslog_config_file_format == 'advanced' %}
+# ### sample forwarding rule ###
+action(type="omfwd"
+# # An on-disk queue is created for this action. If the remote host is
+# # down, messages are spooled to disk and sent when it is up again.
+#queue.filename="fwdRule1"       # unique name prefix for spool files
+#queue.maxdiskspace="1g"         # 1gb space limit (use as much as possible)
+#queue.saveonshutdown="on"       # save messages to disk on shutdown
+#queue.type="LinkedList"         # run asynchronously
+#action.resumeRetryCount="-1"    # infinite retries if host is down
+# # Remote Logging (we use TCP for reliable delivery)
+# # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
+#Target="remote_host" Port="XXX" Protocol="tcp")
+Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" KeepAlive="on")
+{% endif %}


### PR DESCRIPTION
Hi Robert, thanks for sharing your role with community.

---
name: Added forward rule in rsyslog directory
about: rsyslog forward rule file

---

**Describe the change**

Currently the log forwads rule is written directly in rsyslog.conf, this means that the default config is overwritten.
This can cause issues because some want to keep default rsyslog config.
In my case ( debian duster 10), it was different from your default legacy/advanced file so i needed a way to keep it as it is and just a dd a forward rule.  

Here's my rsyslo conf file:

```
# /etc/rsyslog.conf configuration file for rsyslog
#
# For more information install rsyslog-doc and see
# /usr/share/doc/rsyslog-doc/html/configuration/index.html


#################
#### MODULES ####
#################

module(load="imuxsock") # provides support for local system logging
module(load="imklog")   # provides kernel logging support
#module(load="immark")  # provides --MARK-- message capability

# provides UDP syslog reception
#module(load="imudp")
#input(type="imudp" port="514")

# provides TCP syslog reception
#module(load="imtcp")
#input(type="imtcp" port="514")


###########################
#### GLOBAL DIRECTIVES ####
###########################

#
# Use traditional timestamp format.
# To enable high precision timestamps, comment out the following line.
#
$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat

#
# Set the default permissions for all log files.
#
$FileOwner root
$FileGroup adm
$FileCreateMode 0640
$DirCreateMode 0755
$Umask 0022

#
# Where to place spool and state files
#
$WorkDirectory /var/spool/rsyslog

#
# Include all config files in /etc/rsyslog.d/
#
$IncludeConfig /etc/rsyslog.d/*.conf


###############
#### RULES ####
###############

#
# First some standard log files.  Log by facility.
#
auth,authpriv.*                 /var/log/auth.log
*.*;auth,authpriv.none          -/var/log/syslog
#cron.*                         /var/log/cron.log
daemon.*                        -/var/log/daemon.log
kern.*                          -/var/log/kern.log
lpr.*                           -/var/log/lpr.log
mail.*                          -/var/log/mail.log
user.*                          -/var/log/user.log

#
# Logging for the mail system.  Split it up so that
# it is easy to write scripts to parse these files.
#
mail.info                       -/var/log/mail.info
mail.warn                       -/var/log/mail.warn
mail.err                        /var/log/mail.err

#
# Some "catch-all" log files.
#
*.=debug;\
        auth,authpriv.none;\
        news.none;mail.none     -/var/log/debug
*.=info;*.=notice;*.=warn;\
        auth,authpriv.none;\
        cron,daemon.none;\
        mail,news.none          -/var/log/messages

#
# Emergencies are sent to everybody logged in.
#
*.emerg                         :omusrmsg:*

```

Also, when rsyslog_deploy_default_config is set to false, rsyslog can't start because no rules were added.
I changed the behaviour rsyslog_deploy_default_config so that:
    - when true the behaviour is the same as previously
    - when it's false, rsyslog.conf is not overwritten but a new forward rule file ( named after a new variable rsyslog_forward_rule_name) is created in /etc/rsysconf.d based on new template file forward_rule.conf.j2.

**Testing**
Molecule test provided
