### PR TITLE
Only set $OmitLocalLogging if immuxsock is loaded

### DIFF
--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -37,7 +37,7 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 
 # Turn off message reception via local log socket;
 # local messages are retrieved through imjournal now.
-{{ '#' if 'imuxsock' in rsyslog_mods else '' }}$OmitLocalLogging on
+{{ '#' if not 'imuxsock' in rsyslog_mods else '' }}$OmitLocalLogging on
 
 # File to store the position in the journal
 {{ '#' if not 'imjournal' in rsyslog_mods else '' }}$IMJournalStateFile imjournal.state


### PR DESCRIPTION
---
name: Only set $OmitLocalLogging if immuxsock is loaded
about: This an  error when `immuxsock` is not loaded

---

**Describe the change**
Fixes this error when `immuxsock` is not loaded:

```
invalid or yet-unknown config file command 'OmitLocalLogging'
```

This configuration matches the logic in the advanced template.

**Testing**
I ran the role with a playbook with the following variables:
```
rsyslog_config_file_format: legacy
rsyslog_mods:
  - immark
```
