### PR TITLE
Updated rsyslog_deploy_default_config expected type from string to bool

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     src: "{{ rsyslog_config_file_format }}_rsyslog.conf.j2"
     dest: /etc/rsyslog.conf
     mode: "0644"
-  when: rsyslog_deploy_default_config == "yes"
+  when: rsyslog_deploy_default_config|bool == true
   notify:
     - restart rsyslog
 
@@ -34,7 +34,7 @@
     src: "forward_rule.conf.j2"
     dest: /etc/rsyslog.d/{{ rsyslog_forward_rule_name }}.conf
     mode: "0644"
-  when: rsyslog_deploy_default_config == "no"
+  when: rsyslog_deploy_default_config|bool == false
   notify:
     - restart rsyslog
 


### PR DESCRIPTION
Hi Robert, this PR is an enhancement of my  previous PR https://github.com/robertdebock/ansible-role-rsyslog/pull/10

---
name: Updated rsyslog_deploy_default_config test with bool
about: rsyslog forward rule file

---

**Describe the change**
Currently,rsyslog_deploy_default_config must be a string "yes" or "no"   instead of booleans: yes,no without "". This commit allows to use boolean by updating the test in main.yml


**Testing**
Molecule test provided.
