### PR TITLE
Add ability to configure rsyslog package state to support updating package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,7 @@ rsyslog_config_file_format: legacy
 
 # The rule conf to name to add to /etc/rsyslog.d/
 # rsyslog_forward_rule_name: <to fill>
+
+# Configure the rsyslog package to be present, or set to latest to install the
+# latest available version.
+rsyslog_package_state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: install rsyslog
   package:
     name: "{{ rsyslog_packages }}"
-    state: present
+    state: "{{ rsyslog_package_state }}"
 
 - name: configuring default rsyslog
   template:


### PR DESCRIPTION
Allow setting the package state to allow updating rsyslog for hosts
where it is already installed, by setting rsyslog_package_state: latest.