### PR TITLE
Update bool assertions

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -4,7 +4,7 @@
   ansible.builtin.assert:
     that:
       - rsyslog_receiver is defined
-      - rsyslog_receiver is boolean
+      - rsyslog_receiver | bool
     quiet: yes
   when:
     - rsyslog_receiver is defined
@@ -59,7 +59,7 @@
   ansible.builtin.assert:
     that:
       - rsyslog_deploy_default_config is defined
-      - rsyslog_deploy_default_config is boolean
+      - rsyslog_deploy_default_config | bool
     quiet: yes
 
 - name: test if rsyslog_forward_rule_name is set correctly

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -4,7 +4,7 @@
   ansible.builtin.assert:
     that:
       - rsyslog_receiver is defined
-      - rsyslog_receiver | bool
+      - rsyslog_receiver | type_debug == "bool"
     quiet: yes
   when:
     - rsyslog_receiver is defined
@@ -59,7 +59,7 @@
   ansible.builtin.assert:
     that:
       - rsyslog_deploy_default_config is defined
-      - rsyslog_deploy_default_config | bool
+      - rsyslog_deploy_default_config | type_debug == "bool"
     quiet: yes
 
 - name: test if rsyslog_forward_rule_name is set correctly


### PR DESCRIPTION
---
name: Update bool assertions
about: Update assertions to use type_debug to test variable is bool

---

**Describe the change**
Hi there! I started running into an issue where I was receiving this failure:

```
FAILED! => {"msg": "The conditional check 'rsyslog_deploy_default_config is boolean' failed. The error was: template error while templating string: no test named 'boolean'. String: {% if rsyslog_deploy_default_config is boolean %} True {% else %} False {% endif %}"}
```

After some digging and testing, I have not been able to find any documentation to contradict the error saying that there is no conditional check of `is boolean` for Jinja2 or Ansible. 

So I found the following syntax to check for whether a variable is of the type "bool" or not:

`| type_debug == "bool"`

This change simply replaces two instances of `is boolean` with `| type_debug == "bool"` in the assert.yml file. 

**Testing**
I tested this change in an existing playbook I had:

```yaml
- name: configure hosts
  hosts: <remote_host>
  roles:
  - role: rsyslog
    become: True
    vars:
      rsyslog_remote: <remote_logserver>
```

Using the ansible version:
```
ansible 2.9.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.8.5 (default, Jul 28 2020, 12:59:40) [GCC 9.3.0]
```

