### PR TITLE
Add variables to setup default rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ rsyslog_mods:
 # Configure rsyslog minimally (may be in conflict with custom configuration files)
 rsyslog_deploy_default_config: yes
 
+# Default rsyslogd rules
+rsyslog_default_rules:
+  - { rule: '*.info;mail.none;authpriv.none;cron.none', logpath: '/var/log/messages' }
+  - { rule: 'authpriv.*', logpath: '/var/log/secure' }
+  - { rule: 'mail.*', logpath: '-/var/log/maillog' }
+  - { rule: 'cron.*', logpath: '/var/log/cron' }
+  - { rule: '*.emerg', logpath: ':omusrmsg:*' }
+  - { rule: 'uucp,news.crit', logpath: '/var/log/spooler' }
+  - { rule: 'local7.*', logpath: '/var/log/boot.log' }
+
 # Use the (obsolete) legacy, pre-v6 configuration file format, or the more
 # modern # 'advanced' configuration file format available in v6 and up. The
 # default is to use the 'legacy' format to not change config files for

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,16 @@ rsyslog_mods:
 # Configure rsyslog minimally (may be in conflict with custom configuration files)
 rsyslog_deploy_default_config: yes
 
+# Default rsyslogd rules
+rsyslog_default_rules:
+  - { rule: '*.info;mail.none;authpriv.none;cron.none', logpath: '/var/log/messages' }
+  - { rule: 'authpriv.*', logpath: '/var/log/secure' }
+  - { rule: 'mail.*', logpath: '-/var/log/maillog' }
+  - { rule: 'cron.*', logpath: '/var/log/cron' }
+  - { rule: '*.emerg', logpath: ':omusrmsg:*' }
+  - { rule: 'uucp,news.crit', logpath: '/var/log/spooler' }
+  - { rule: 'local7.*', logpath: '/var/log/boot.log' }
+
 # Use the (obsolete) legacy, pre-v6 configuration file format, or the more
 # modern # 'advanced' configuration file format available in v6 and up. The
 # default is to use the 'legacy' format to not change config files for

--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -50,36 +50,12 @@ $PreserveFQDN on
 {{ '' if rsyslog_receiver is defined else '#' }}module(load="imtcp") # needs to be done just once
 {{ '' if rsyslog_receiver is defined else '#' }}input(type="imtcp" port="514")
 
-{% if rsyslog_deploy_default_config %}
+{% if rsyslog_default_rules|length > 0 %}
 #### RULES ####
-
-# Log all kernel messages to the console.
-# Logging much else clutters up the screen.
-#kern.*                                                 /dev/console
-
-# Log anything (except mail) of level info or higher.
-# Don't log private authentication messages!
-*.info;mail.none;authpriv.none;cron.none                /var/log/messages
-
-# The authpriv file has restricted access.
-authpriv.*                                              /var/log/secure
-
-# Log all the mail messages in one place.
-mail.*                                                  -/var/log/maillog
-
-
-# Log cron stuff
-cron.*                                                  /var/log/cron
-
-# Everybody gets emergency messages
-*.emerg                                                 :omusrmsg:*
-
-# Save news errors of level crit and higher in a special file.
-uucp,news.crit                                          /var/log/spooler
-
-# Save boot messages also to boot.log
-local7.*                                                /var/log/boot.log
-
+{% for item in rsyslog_default_rules | default([]) %}
+{{ item.rule }} {{ item.logpath }}
+{% endfor %}
+{% endif %}
 
 {% if rsyslog_remote is defined %}
 # ### sample forwarding rule ###
@@ -95,6 +71,5 @@ action(type="omfwd"
 # # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
 #Target="remote_host" Port="XXX" Protocol="tcp")
 Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}")
-{% endif %}
 # ### end of the forwarding rule ###
 {% endif %}

--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -51,37 +51,14 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 $DirCreateMode {{ rsyslog_dircreatemode }}
 $FileCreateMode {{ rsyslog_filecreatemode }}
 
-{% if rsyslog_deploy_default_config %}
+{% if rsyslog_default_rules|length > 0 %}
 #### RULES ####
+{% for item in rsyslog_default_rules | default([]) %}
+{{ item.rule }} {{ item.logpath }}
+{% endfor %}
+{% endif %}
 
-# Log all kernel messages to the console.
-# Logging much else clutters up the screen.
-#kern.*                                                 /dev/console
-
-# Log anything (except mail) of level info or higher.
-# Don't log private authentication messages!
-*.info;mail.none;authpriv.none;cron.none                /var/log/messages
-
-# The authpriv file has restricted access.
-authpriv.*                                              /var/log/secure
-
-# Log all the mail messages in one place.
-mail.*                                                  -/var/log/maillog
-
-
-# Log cron stuff
-cron.*                                                  /var/log/cron
-
-# Everybody gets emergency messages
-*.emerg                                                 :omusrmsg:*
-
-# Save news errors of level crit and higher in a special file.
-uucp,news.crit                                          /var/log/spooler
-
-# Save boot messages also to boot.log
-local7.*                                                /var/log/boot.log
-
-
+{% if rsyslog_remote is defined %}
 # ### begin forwarding rule ###
 # The statement between the begin ... end define a SINGLE forwarding
 # rule. They belong together, do NOT split them. If you create multiple
@@ -97,8 +74,6 @@ local7.*                                                /var/log/boot.log
 #$ActionResumeRetryCount -1    # infinite retries if host is down
 # remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
 #*.* @@remote-host:514
-{% if rsyslog_remote is defined %}
 {{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
-{% endif %}
 # ### end of the forwarding rule ###
 {% endif %}


### PR DESCRIPTION
---
name: Pull request
about: Add variables to setup default rules

---

**Describe the change**
Currently if you set the variable rsyslog_deploy_default_config to no, the default file is not deployed. In the template you have a condition ```{% if rsyslog_deploy_default_config %}``` which is never true.
So I replaced in the template by a new variables called `rsyslog_default_rules` containing the rules.

**Testing**
Deployed with the default values and with a variable `rsyslog_default_rules` containing some new default rules.
