### PR TITLE
Add multiple configuration capability

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,6 @@ rsyslog_package_state: present
 # part from a name that is within the same domain as the receiving system is
 # stripped. If set to on, full names are always used.
 rsyslog_preservefqdn: false
+
+# Configure additional config files in /etc/rsyslog.d
+rsyslog_rsyslog_d_files: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,18 @@
   notify:
     - restart rsyslog
 
+- name: configuring additional config files
+  ansible.builtin.copy:
+    content: "{{ item.value.content | default('') }}"
+    dest: "/etc/rsyslog.d/{{ item.key }}.conf"
+    validate: "{{ 'rsyslogd -N1 -f %s' if item.value.validate | default(false) else 'true %s' }}"
+    owner: root
+    group: root
+    mode: 0440
+  with_dict: "{{ rsyslog_rsyslog_d_files }}"
+  when: item.value.state | default('present') == 'present'
+  notify: restart rsyslog
+
 - name: start and enable rsyslog
   ansible.builtin.service:
     name: "{{ rsyslog_service }}"


### PR DESCRIPTION
---
name: Pull request
about: Capability to add syslog.d files in this role

---

**Describe the change**
Able to add additional config files with example config below:
```yaml
rsyslog_rsyslog_d_files:                                                                            
  app01:                                                                                  
    content: |                                                                                      
      input(type="imfile" file="/var/log/app01.log" tag="app01" severity="info" facility="local6" ruleset="sendToOther")
      ruleset(name="sendToOther") {                                                                
        action(type="omfwd" target="other" port="514" protocol="tcp")
      }
```

**Testing**
Deployed
