### PR TITLE
Fix rsyslog_receiver boolean behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ These variables are set in `defaults/main.yml`:
 ---
 # defaults file for rsyslog
 
-# To configure a server to reveice logs, set rsyslog_receiver to yes.
-# Not setting this value will not configure the server tor receive logs.
-# rsyslog_receiver: yes
+# To configure a server to receive logs, set rsyslog_receiver to yes.
+rsyslog_receiver: no
 
 # To forward logs to another server, set rsyslog_remote to the hostname or
 # the ipaddress of the receiving rsyslog server.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,8 @@
 ---
 # defaults file for rsyslog
 
-# To configure a server to reveice logs, set rsyslog_receiver to yes.
-# Not setting this value will not configure the server tor receive logs.
-# rsyslog_receiver: yes
+# To configure a server to receive logs, set rsyslog_receiver to yes.
+rsyslog_receiver: no
 
 # To forward logs to another server, set rsyslog_remote to the hostname or
 # the ipaddress of the receiving rsyslog server.

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -6,8 +6,6 @@
       - rsyslog_receiver is defined
       - rsyslog_receiver is boolean
     quiet: yes
-  when:
-    - rsyslog_receiver is defined
 
 - name: test if rsyslog_preservefqdn is set correctly
   ansible.builtin.assert:

--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -28,12 +28,12 @@
 {{ '' if 'imfile' in rsyslog_mods else '#' }}module(load="imfile")
 
 # provides UDP syslog reception
-{{ '' if rsyslog_receiver is defined else '#' }}module(load="imudp") # needs to be done just once
-{{ '' if rsyslog_receiver is defined else '#' }}input(type="imudp" port="514")
+{{ '' if rsyslog_receiver else '#' }}module(load="imudp") # needs to be done just once
+{{ '' if rsyslog_receiver else '#' }}input(type="imudp" port="514")
 
 # provides TCP syslog reception
-{{ '' if rsyslog_receiver is defined else '#' }}module(load="imtcp") # needs to be done just once
-{{ '' if rsyslog_receiver is defined else '#' }}input(type="imtcp" port="514")
+{{ '' if rsyslog_receiver else '#' }}module(load="imtcp") # needs to be done just once
+{{ '' if rsyslog_receiver else '#' }}input(type="imtcp" port="514")
 
 ###########################
 #### GLOBAL DIRECTIVES ####

--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -17,12 +17,12 @@
 {{ '#' if not 'imfile'    in rsyslog_mods else '' }}$ModLoad imfile    # provides access to specific log file
 
 # provides UDP syslog reception
-{{ '' if rsyslog_receiver is defined else '#' }}$ModLoad imudp
-{{ '' if rsyslog_receiver is defined else '#' }}$UDPServerRun 514
+{{ '' if rsyslog_receiver else '#' }}$ModLoad imudp
+{{ '' if rsyslog_receiver else '#' }}$UDPServerRun 514
 
 # provides TCP syslog reception
-{{ '' if rsyslog_receiver is defined else '#' }}$ModLoad imtcp
-{{ '' if rsyslog_receiver is defined else '#' }}$InputTCPServerRun 514
+{{ '' if rsyslog_receiver else '#' }}$ModLoad imtcp
+{{ '' if rsyslog_receiver else '#' }}$InputTCPServerRun 514
 
 
 ###########################


### PR DESCRIPTION
---
name: Fix rsyslog_receiver boolean behavior
about: Addresses #28 

---

**Describe the change**
Changes `rsyslog_receiver` default value and checks to take boolean value into account (instead of simply checking whether it's defined)