### PR TITLE
Add option to disable OmitLocalLogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ rsyslog_features: []
 
 # Default destination of rsyslog config file
 rsyslog_dest_conf_file: "/etc/rsyslog.conf"
+
+# Enable / Disable option OmitLocalLogging
+rsyslog_omit_local_logging: yes
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,3 +91,6 @@ rsyslog_features: []
 
 # Default destination of rsyslog config file
 rsyslog_dest_conf_file: "/etc/rsyslog.conf"
+
+# Enable / Disable option OmitLocalLogging
+rsyslog_omit_local_logging: yes

--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -77,7 +77,7 @@ $PreserveFQDN on
 # Turn off message reception via local log socket;
 # local messages are retrieved through imjournal now.
 #
-{{ '#' if 'imuxsock' in rsyslog_mods else '' }}$OmitLocalLogging on
+{{ '#' if 'imuxsock' in rsyslog_mods or not rsyslog_omit_local_logging else '' }}$OmitLocalLogging on
 
 #
 # File to store the position in the journal


### PR DESCRIPTION
---
name: Add option to disable OmitLocalLogging
about: Need to add an option to remove OmitLocalLogging in config file

---

**Describe the change**
On some equipment the `imuxsock` module is not loaded in the main rsyslog configuration file but in another one. We need to be able to disable `OmitLocalLogging` option in main configuration file even if `imuxsock` is not in `rsyslog_mods` variable.

**Testing**
Deploy the role without changing default: `OmitLocalLogging` option is still there
Deploy the role changing option `rsyslog_dest_conf_file`: `OmitLocalLogging` option removed
