### PR TITLE
fix: Use $IncludeConfig in advanced config

### DIFF
--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -77,7 +77,7 @@ $PreserveFQDN on
 #
 # Include all config files in /etc/rsyslog.d/
 #
-include(file="/etc/rsyslog.d/*.conf" mode="optional")
+$IncludeConfig /etc/rsyslog.d/*.conf
 
 ###############
 #### RULES ####


### PR DESCRIPTION
Changes the `include(...)` line to use `$IncludeConfig`.   This eliminates the errors about include.  eg. 
```
 action 'include' treated as ':omusrmsg:include' - please use ':omusrmsg:include' syntax instead, 'include' will not be supported in the future [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2184 ]
```

Fixes: #34

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

**Testing**
In case a feature was added, how were tests performed?
