### PR TITLE
[rsyslog_remote] could have more than one server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,12 @@
 rsyslog_receiver: no
 
 # To forward logs to another server, set rsyslog_remote to the hostname or
-# the ipaddress of the receiving rsyslog server.
+# the ipaddress of the receiving rsyslog server. Could also be a list of
+# servers
 # Not setting this variable will not forward logs.
-# rsyslog_remote: server1.example.com
+# rsyslog_remote:
+#  - server1.example.com
+#  - server2.example.com
 
 # If rsylog_remote is set, sets the "selector" pattern for determining which
 # messages to send to the remote server.  Default "*.*" sends everything.

--- a/templates/forward_rule.conf.j2
+++ b/templates/forward_rule.conf.j2
@@ -17,7 +17,9 @@
 #$ActionResumeRetryCount -1    # infinite retries if host is down
 # remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
 #*.* @@remote-host:514
-{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
+{% for remoteserver in rsyslog_remote %}
+{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ remoteserver }}:{{ rsyslog_remote_port }}
+{% endfor %}
 {% endif %}
 # ### end of the forwarding rule ###
 
@@ -34,5 +36,7 @@ action(type="omfwd"
 # # Remote Logging (we use TCP for reliable delivery)
 # # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
 #Target="remote_host" Port="XXX" Protocol="tcp")
-Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if not rsyslog_remote_template else 'template="' + rsyslog_remote_template + '"' }} KeepAlive="on")
+{% for remoteserver in rsyslog_remote %}
+Target="{{ remoteserver }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if not rsyslog_remote_template else 'template="' + rsyslog_remote_template + '"' }} KeepAlive="on")
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
---
name: possibility to have more than one remote
about: making a list of the `rsyslog_remote` variable

---

**Describe the change**
Extent the role by the possibility to have more than one `rsyslog_remote`
**Testing**
In case a feature was added, how were tests performed?
- implemented it on our cluster with 2 targets and also tested with only one server wheather the jinja2 template works as usual there. 