### PR TITLE
Add support for multiple remotes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,16 +9,9 @@ rsyslog_receiver: no
 # Not setting this variable will not forward logs.
 # rsyslog_remote: server1.example.com
 
-# If rsylog_remote is set, sets the "selector" pattern for determining which
-# messages to send to the remote server.  Default "*.*" sends everything.
-# See `man rsyslog.conf`.
-rsyslog_remote_selector: "*.*"
-
-# If rsylog_remote is set, use TCP if yes. UDP if no.
-rsyslog_remote_tcp: yes
-
-# If rsylog_remote is set, destination port to use.
-rsyslog_remote_port: 514
+# If rsyslog_remotes has items, forwards logs matching the selector field to
+# the destination specified by the hostname, port, and tcp fields.
+rsyslog_remotes: []
 
 # Set the mode for new directories; only available in legacy template.
 rsyslog_dircreatemode: "0700"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,13 +4,12 @@
 # To configure a server to receive logs, set rsyslog_receiver to yes.
 rsyslog_receiver: no
 
-# To forward logs to another server, set rsyslog_remote to the hostname or
-# the ipaddress of the receiving rsyslog server.
-# Not setting this variable will not forward logs.
-# rsyslog_remote: server1.example.com
-
-# If rsyslog_remotes has items, forwards logs matching the selector field to
-# the destination specified by the hostname, port, and tcp fields.
+# To forward logs to a remote server, add items to the rsyslog_remotes list.
+# Each item should be a map like the following:
+# - selector: *.*
+#   hostname: logging.server.net
+#   port: 514 (optional, default 514)
+#   tcp: yes (optional, default yes)
 rsyslog_remotes: []
 
 # Set the mode for new directories; only available in legacy template.

--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -89,22 +89,37 @@ include(file="/etc/rsyslog.d/*.conf" mode="optional")
 {% endfor %}
 {% endif %}
 
-{% if rsyslog_remote is defined %}
-#########################
-#### FORWARDING RULE ####
-#########################
+##########################
+#### FORWARDING RULES ####
+##########################
 
-action(type="omfwd"
-# # An on-disk queue is created for this action. If the remote host is
-# # down, messages are spooled to disk and sent when it is up again.
+# The statement between the begin and end comments define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+
+# An on-disk queue is created for these actions. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+
+# Example
+# *.* action(type="omfwd" Target="logging.server.net" Port="514" Protocol="tcp")
+
+{% for remote in rsyslog_remotes %}
+### begin forwarding rule ###
+# Uncomment the lines below if you wish to configure further.
 #queue.filename="fwdRule1"       # unique name prefix for spool files
 #queue.maxdiskspace="1g"         # 1gb space limit (use as much as possible)
 #queue.saveonshutdown="on"       # save messages to disk on shutdown
 #queue.type="LinkedList"         # run asynchronously
 #action.resumeRetryCount="-1"    # infinite retries if host is down
-# # Remote Logging (we use TCP for reliable delivery)
-# # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
-#Target="remote_host" Port="XXX" Protocol="tcp")
-Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if not rsyslog_remote_template else 'template="' + rsyslog_remote_template + '"' }})
-# ### end of the forwarding rule ###
+{{ remote.selector }} action(type="omfwd" Target="{{ remote.hostname }}"
+{% if remote.port %}
+Port="{{ remote.port }}"
 {% endif %}
+Protocol="{{ 'tcp' if remote.tcp else 'udp' }}"
+{% if remote.template %}
+Template="{{ remote.template }}"
+{% endif %}
+KeepAlive="on")
+### end forwarding rule ###
+
+{% endfor %}

--- a/templates/forward_rule.conf.j2
+++ b/templates/forward_rule.conf.j2
@@ -1,38 +1,52 @@
 {{ ansible_managed | comment }}
 
-# ### begin forwarding rule ###
-# The statement between the begin ... end define a SINGLE forwarding
+# The statement between the begin and end comments define a SINGLE forwarding
 # rule. They belong together, do NOT split them. If you create multiple
 # forwarding rules, duplicate the whole block!
-# Remote Logging (we use TCP for reliable delivery)
-#
 
-{% if rsyslog_remote is defined  and rsyslog_config_file_format == 'legacy' %}
-# An on-disk queue is created for this action. If the remote host is
+# An on-disk queue is created for these actions. If the remote host is
 # down, messages are spooled to disk and sent when it is up again.
+
+{% if rsyslog_config_file_format == 'legacy' %}
+# Example
+# *.* @@logging.server.net:514
+
+{% for remote in rsyslog_remotes %}
+### begin forwarding rule ###
+# Uncomment the lines below if you wish to configure further.
 #$ActionQueueFileName fwdRule1 # unique name prefix for spool files
 #$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
 #$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
 #$ActionQueueType LinkedList   # run asynchronously
 #$ActionResumeRetryCount -1    # infinite retries if host is down
-# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
-#*.* @@remote-host:514
-{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
-{% endif %}
-# ### end of the forwarding rule ###
+{{ remote.selector }} {{ '@@' if remote.tcp else '@' }}{{ remote.hostname }}{{ ':' if remote.port }}{{ remote.port }}
+### end forwarding rule ###
 
-{% if rsyslog_remote is defined and rsyslog_config_file_format == 'advanced' %}
-# ### sample forwarding rule ###
-action(type="omfwd"
-# # An on-disk queue is created for this action. If the remote host is
-# # down, messages are spooled to disk and sent when it is up again.
+{% endfor %}
+{% endif %}
+
+{% if rsyslog_config_file_format == 'advanced' %}
+# Example
+# *.* action(type="omfwd" Target="logging.server.net" Port="514" Protocol="tcp")
+
+{% for remote in rsyslog_remotes %}
+### begin forwarding rule ###
+# Uncomment the lines below if you wish to configure further.
 #queue.filename="fwdRule1"       # unique name prefix for spool files
 #queue.maxdiskspace="1g"         # 1gb space limit (use as much as possible)
 #queue.saveonshutdown="on"       # save messages to disk on shutdown
 #queue.type="LinkedList"         # run asynchronously
 #action.resumeRetryCount="-1"    # infinite retries if host is down
-# # Remote Logging (we use TCP for reliable delivery)
-# # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
-#Target="remote_host" Port="XXX" Protocol="tcp")
-Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if not rsyslog_remote_template else 'template="' + rsyslog_remote_template + '"' }} KeepAlive="on")
+{{ remote.selector }} action(type="omfwd" Target="{{ remote.hostname }}"
+{% if remote.port %}
+Port="{{ remote.port }}"
+{% endif %}
+Protocol="{{ 'tcp' if remote.tcp else 'udp' }}"
+{% if remote.template %}
+Template="{{ remote.template }}"
+{% endif %}
+KeepAlive="on")
+### end forwarding rule ###
+
+{% endfor %}
 {% endif %}

--- a/templates/legacy_rsyslog.conf.j2
+++ b/templates/legacy_rsyslog.conf.j2
@@ -96,25 +96,29 @@ $PreserveFQDN on
 {% endfor %}
 {% endif %}
 
-{% if rsyslog_remote is defined %}
-#########################
-#### FORWARDING RULE ####
-#########################
+##########################
+#### FORWARDING RULES ####
+##########################
 
-# The statement between the begin ... end define a SINGLE forwarding
+# The statement between the begin and end comments define a SINGLE forwarding
 # rule. They belong together, do NOT split them. If you create multiple
 # forwarding rules, duplicate the whole block!
-# Remote Logging (we use TCP for reliable delivery)
-#
-# An on-disk queue is created for this action. If the remote host is
+
+# An on-disk queue is created for these actions. If the remote host is
 # down, messages are spooled to disk and sent when it is up again.
+
+# Example
+# *.* @@logging.server.net:514
+
+{% for remote in rsyslog_remotes %}
+### begin forwarding rule ###
+# Uncomment the lines below if you wish to configure further.
 #$ActionQueueFileName fwdRule1 # unique name prefix for spool files
 #$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
 #$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
 #$ActionQueueType LinkedList   # run asynchronously
 #$ActionResumeRetryCount -1    # infinite retries if host is down
-# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
-#*.* @@remote-host:514
-{{ rsyslog_remote_selector }} {{ '@@' if rsyslog_remote_tcp else '@' }}{{ rsyslog_remote }}:{{ rsyslog_remote_port }}
-# ### end of the forwarding rule ###
-{% endif %}
+{{ remote.selector }} {{ '@@' if remote.tcp else '@' }}{{ remote.hostname }}{{ ':' if remote.port }}{{ remote.port }}
+### end forwarding rule ###
+
+{% endfor %}


### PR DESCRIPTION
---
name: Add support for multiple remotes
about: This PR changes the forwarding rule templates to allow configuration of multiple remotes. 

---

**Describe the change**
Each remote can have a selector pattern, hostname, and port configured as well as whether to use tcp.