### PR TITLE
feat: Add support for Device when forwarding logs

### DIFF
--- a/templates/forward_rule.conf.j2
+++ b/templates/forward_rule.conf.j2
@@ -34,5 +34,5 @@ action(type="omfwd"
 # # Remote Logging (we use TCP for reliable delivery)
 # # remote_host is: name/ip, e.g. 192.168.0.1, port optional e.g. 10514
 #Target="remote_host" Port="XXX" Protocol="tcp")
-Target="{{ rsyslog_remote }}" Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if not rsyslog_remote_template else 'template="' + rsyslog_remote_template + '"' }} KeepAlive="on")
+Target="{{ rsyslog_remote }}" {{ '' if rsyslog_remote_device is not defined else 'Device="' + rsyslog_remote_device + '"' }} Port="{{ rsyslog_remote_port }}" Protocol="{{ 'tcp' if rsyslog_remote_tcp else 'udp' }}" {{ '' if rsyslog_remote_template is not defined else 'template="' + rsyslog_remote_template + '"' }} KeepAlive="on")
 {% endif %}


### PR DESCRIPTION
---
name: Add device when forwarding logs
about: Add support for setting the device when forwarding logs

---

**Describe the change**
When the device has multiple VRFs, it may be required to set the device when forwarding the logs. This adds that feature.
It also fixes the error when `rsyslog_remote_template` is not defined.

